### PR TITLE
Correct string output of murmurHash3.x86.hash128

### DIFF
--- a/murmurHash3.js
+++ b/murmurHash3.js
@@ -424,7 +424,7 @@
 		h3 += h1;
 		h4 += h1;
 		
-		return ("00000000" + (h2 >>> 0).toString(16)).slice(-8) + ("00000000" + (h1 >>> 0).toString(16)).slice(-8) + ("00000000" + (h4 >>> 0).toString(16)).slice(-8) + ("00000000" + (h3 >>> 0).toString(16)).slice(-8);
+		return ("00000000" + (h1 >>> 0).toString(16)).slice(-8) + ("00000000" + (h2 >>> 0).toString(16)).slice(-8) + ("00000000" + (h3 >>> 0).toString(16)).slice(-8) + ("00000000" + (h4 >>> 0).toString(16)).slice(-8);
 	};
 	
 	


### PR DESCRIPTION
The original version of this file returned 128bit hex strings with the chunks in the wrong order.  The output of the x86 128bit hex string function of this library was inconsistent with other libraries.

The file was returning hashes with the chunks in the order.
h2 h1 h4 h3

I have changed the x86.hash128 function to correctly follow the original code base.  The chunks are now output in the order.

h1 h2 h3 h4

Reference:
https://code.google.com/p/smhasher/source/browse/trunk/MurmurHash3.cpp