### PR TITLE
Make output match C++ reference

### DIFF
--- a/murmurHash3.js
+++ b/murmurHash3.js
@@ -9,578 +9,596 @@
 
 ;(function (root, undefined) {
 	'use strict';
-	
+
 	// Create a local object that'll be exported or referenced globally.
 	var library = {
 		'version': '2.1.2',
 		'x86': {},
 		'x64': {}
 	};
-	
-	
-	
-	
+
+
+
+
 	// PRIVATE FUNCTIONS
 	// -----------------
-	
+
 	function _x86Multiply(m, n) {
 		//
 		// Given two 32bit ints, returns the two multiplied together as a
 		// 32bit int.
 		//
-		
+
 		return ((m & 0xffff) * n) + ((((m >>> 16) * n) & 0xffff) << 16);
 	}
-	
-	
+
+
 	function _x86Rotl(m, n) {
 		//
 		// Given a 32bit int and an int representing a number of bit positions,
 		// returns the 32bit int rotated left by that number of positions.
 		//
-		
+
 		return (m << n) | (m >>> (32 - n));
 	}
-	
-	
+
+
 	function _x86Fmix(h) {
 		//
 		// Given a block, returns murmurHash3's final x86 mix of that block.
 		//
-		
+
 		h ^= h >>> 16;
 		h  = _x86Multiply(h, 0x85ebca6b);
 		h ^= h >>> 13;
 		h  = _x86Multiply(h, 0xc2b2ae35);
 		h ^= h >>> 16;
-		
+
 		return h;
 	}
-	
-	
+
+
 	function _x64Add(m, n) {
 		//
 		// Given two 64bit ints (as an array of two 32bit ints) returns the two
 		// added together as a 64bit int (as an array of two 32bit ints).
 		//
-		
+
 		m = [m[0] >>> 16, m[0] & 0xffff, m[1] >>> 16, m[1] & 0xffff];
 		n = [n[0] >>> 16, n[0] & 0xffff, n[1] >>> 16, n[1] & 0xffff];
 		var o = [0, 0, 0, 0];
-		
+
 		o[3] += m[3] + n[3];
 		o[2] += o[3] >>> 16;
 		o[3] &= 0xffff;
-		
+
 		o[2] += m[2] + n[2];
 		o[1] += o[2] >>> 16;
 		o[2] &= 0xffff;
-		
+
 		o[1] += m[1] + n[1];
 		o[0] += o[1] >>> 16;
 		o[1] &= 0xffff;
-		
+
 		o[0] += m[0] + n[0];
 		o[0] &= 0xffff;
-		
+
 		return [(o[0] << 16) | o[1], (o[2] << 16) | o[3]];
 	}
-	
-	
+
+
 	function _x64Multiply(m, n) {
 		//
 		// Given two 64bit ints (as an array of two 32bit ints) returns the two
 		// multiplied together as a 64bit int (as an array of two 32bit ints).
 		//
-		
+
 		m = [m[0] >>> 16, m[0] & 0xffff, m[1] >>> 16, m[1] & 0xffff];
 		n = [n[0] >>> 16, n[0] & 0xffff, n[1] >>> 16, n[1] & 0xffff];
 		var o = [0, 0, 0, 0];
-		
+
 		o[3] += m[3] * n[3];
 		o[2] += o[3] >>> 16;
 		o[3] &= 0xffff;
-		
+
 		o[2] += m[2] * n[3];
 		o[1] += o[2] >>> 16;
 		o[2] &= 0xffff;
-		
+
 		o[2] += m[3] * n[2];
 		o[1] += o[2] >>> 16;
 		o[2] &= 0xffff;
-		
+
 		o[1] += m[1] * n[3];
 		o[0] += o[1] >>> 16;
 		o[1] &= 0xffff;
-		
+
 		o[1] += m[2] * n[2];
 		o[0] += o[1] >>> 16;
 		o[1] &= 0xffff;
-		
+
 		o[1] += m[3] * n[1];
 		o[0] += o[1] >>> 16;
 		o[1] &= 0xffff;
-		
+
 		o[0] += (m[0] * n[3]) + (m[1] * n[2]) + (m[2] * n[1]) + (m[3] * n[0]);
 		o[0] &= 0xffff;
-		
+
 		return [(o[0] << 16) | o[1], (o[2] << 16) | o[3]];
 	}
-	
-	
+
+
 	function _x64Rotl(m, n) {
 		//
 		// Given a 64bit int (as an array of two 32bit ints) and an int
 		// representing a number of bit positions, returns the 64bit int (as an
 		// array of two 32bit ints) rotated left by that number of positions.
 		//
-		
+
 		n %= 64;
-		
+
 		if (n === 32) {
 			return [m[1], m[0]];
 		}
-		
+
 		else if (n < 32) {
 			return [(m[0] << n) | (m[1] >>> (32 - n)), (m[1] << n) | (m[0] >>> (32 - n))];
 		}
-		
+
 		else {
 			n -= 32;
 			return [(m[1] << n) | (m[0] >>> (32 - n)), (m[0] << n) | (m[1] >>> (32 - n))];
 		}
 	}
-	
-	
+
+
 	function _x64LeftShift(m, n) {
 		//
 		// Given a 64bit int (as an array of two 32bit ints) and an int
 		// representing a number of bit positions, returns the 64bit int (as an
 		// array of two 32bit ints) shifted left by that number of positions.
 		//
-		
+
 		n %= 64;
-		
+
 		if (n === 0) {
 			return m;
 		}
-		
+
 		else if (n < 32) {
 			return [(m[0] << n) | (m[1] >>> (32 - n)), m[1] << n];
 		}
-		
+
 		else {
 			return [m[1] << (n - 32), 0];
 		}
 	}
-	
-	
+
+
 	function _x64Xor(m, n) {
 		//
 		// Given two 64bit ints (as an array of two 32bit ints) returns the two
 		// xored together as a 64bit int (as an array of two 32bit ints).
 		//
-		
+
 		return [m[0] ^ n[0], m[1] ^ n[1]];
 	}
-	
-	
+
+
 	function _x64Fmix(h) {
 		//
 		// Given a block, returns murmurHash3's final x64 mix of that block.
 		// (`[0, h[0] >>> 1]` is a 33 bit unsigned right shift. This is the
 		// only place where we need to right shift 64bit ints.)
 		//
-		
+
 		h = _x64Xor(h, [0, h[0] >>> 1]);
 		h = _x64Multiply(h, [0xff51afd7, 0xed558ccd]);
 		h = _x64Xor(h, [0, h[0] >>> 1]);
 		h = _x64Multiply(h, [0xc4ceb9fe, 0x1a85ec53]);
 		h = _x64Xor(h, [0, h[0] >>> 1]);
-		
+
 		return h;
 	}
-	
-	
-	
-	
+
+	// TODO: add polyfill for older browsers / node
+	var textEncoder = new TextEncoder();
+
+	function _utf8Bytes(str) {
+		if (!str) {
+			return [];
+		}
+		var result = [];
+	  for (let i = 0; i < str.length; i++) {
+	    const charCode = str.charCodeAt(i);
+	    if (charCode < 0 || charCode > 127) {
+	      return textEncoder.encode(str);
+	    }
+	    result.push(charCode);
+	  }
+  	return result;
+	}
+
+
+
+
 	// PUBLIC FUNCTIONS
 	// ----------------
-	
-	library.x86.hash32 = function (key, seed) {
+
+	library.x86.hash32 = function (str, seed) {
 		//
 		// Given a string and an optional seed as an int, returns a 32 bit hash
 		// using the x86 flavor of MurmurHash3, as an unsigned int.
 		//
-		
-		key = key || '';
+
+		var bytes = _utf8Bytes(str);
 		seed = seed || 0;
-		
-		var remainder = key.length % 4;
-		var bytes = key.length - remainder;
-		
+
+		var remainder = bytes.length % 4;
+		var blocks = bytes.length - remainder;
+
 		var h1 = seed;
-		
+
 		var k1 = 0;
-		
+
 		var c1 = 0xcc9e2d51;
 		var c2 = 0x1b873593;
-		
-		for (var i = 0; i < bytes; i = i + 4) {
-			k1 = ((key.charCodeAt(i) & 0xff)) | ((key.charCodeAt(i + 1) & 0xff) << 8) | ((key.charCodeAt(i + 2) & 0xff) << 16) | ((key.charCodeAt(i + 3) & 0xff) << 24);
-			
+
+		for (var i = 0; i < blocks; i = i + 4) {
+			k1 = (bytes[i]) | (bytes[i + 1] << 8) | (bytes[i + 2] << 16) | (bytes[i + 3] << 24);
+
 			k1 = _x86Multiply(k1, c1);
 			k1 = _x86Rotl(k1, 15);
 			k1 = _x86Multiply(k1, c2);
-			
+
 			h1 ^= k1;
 			h1 = _x86Rotl(h1, 13);
 			h1 = _x86Multiply(h1, 5) + 0xe6546b64;
 		}
-		
+
 		k1 = 0;
-		
+
 		switch (remainder) {
 			case 3:
-				k1 ^= (key.charCodeAt(i + 2) & 0xff) << 16;
-			
+				k1 ^= bytes[i + 2] << 16;
+
 			case 2:
-				k1 ^= (key.charCodeAt(i + 1) & 0xff) << 8;
-			
+				k1 ^= bytes[i + 1] << 8;
+
 			case 1:
-				k1 ^= (key.charCodeAt(i) & 0xff);
+				k1 ^= bytes[i];
 				k1 = _x86Multiply(k1, c1);
 				k1 = _x86Rotl(k1, 15);
 				k1 = _x86Multiply(k1, c2);
 				h1 ^= k1;
 		}
-		
-		h1 ^= key.length;
+
+		h1 ^= bytes.length;
 		h1 = _x86Fmix(h1);
-		
+
 		return h1 >>> 0;
 	};
-	
-	
-	library.x86.hash128 = function (key, seed) {
+
+
+	library.x86.hash128 = function (str, seed) {
 		//
 		// Given a string and an optional seed as an int, returns a 128 bit
 		// hash using the x86 flavor of MurmurHash3, as an unsigned hex.
 		//
-		
-		key = key || '';
+
+		var bytes = _utf8Bytes(str);
 		seed = seed || 0;
-		
-		var remainder = key.length % 16;
-		var bytes = key.length - remainder;
-		
+
+		var remainder = bytes.length % 16;
+		var blocks = bytes.length - remainder;
+
 		var h1 = seed;
 		var h2 = seed;
 		var h3 = seed;
 		var h4 = seed;
-		
+
 		var k1 = 0;
 		var k2 = 0;
 		var k3 = 0;
 		var k4 = 0;
-		
+
 		var c1 = 0x239b961b;
 		var c2 = 0xab0e9789;
 		var c3 = 0x38b34ae5;
 		var c4 = 0xa1e38b93;
-		
-		for (var i = 0; i < bytes; i = i + 16) {
-			k1 = ((key.charCodeAt(i) & 0xff)) | ((key.charCodeAt(i + 1) & 0xff) << 8) | ((key.charCodeAt(i + 2) & 0xff) << 16) | ((key.charCodeAt(i + 3) & 0xff) << 24);
-			k2 = ((key.charCodeAt(i + 4) & 0xff)) | ((key.charCodeAt(i + 5) & 0xff) << 8) | ((key.charCodeAt(i + 6) & 0xff) << 16) | ((key.charCodeAt(i + 7) & 0xff) << 24);
-			k3 = ((key.charCodeAt(i + 8) & 0xff)) | ((key.charCodeAt(i + 9) & 0xff) << 8) | ((key.charCodeAt(i + 10) & 0xff) << 16) | ((key.charCodeAt(i + 11) & 0xff) << 24);
-			k4 = ((key.charCodeAt(i + 12) & 0xff)) | ((key.charCodeAt(i + 13) & 0xff) << 8) | ((key.charCodeAt(i + 14) & 0xff) << 16) | ((key.charCodeAt(i + 15) & 0xff) << 24);
-			
+
+		for (var i = 0; i < blocks; i = i + 16) {
+			k1 = (bytes[i]) | (bytes[i + 1] << 8) | (bytes[i + 2] << 16) | (bytes[i + 3] << 24);
+			k2 = (bytes[i + 4]) | (bytes[i + 5] << 8) | (bytes[i + 6] << 16) | (bytes[i + 7] << 24);
+			k3 = (bytes[i + 8]) | (bytes[i + 9] << 8) | (bytes[i + 10] << 16) | (bytes[i + 11] << 24);
+			k4 = (bytes[i + 12]) | (bytes[i + 13] << 8) | (bytes[i + 14] << 16) | (bytes[i + 15] << 24);
+
 			k1 = _x86Multiply(k1, c1);
 			k1 = _x86Rotl(k1, 15);
 			k1 = _x86Multiply(k1, c2);
 			h1 ^= k1;
-			
+
 			h1 = _x86Rotl(h1, 19);
 			h1 += h2;
 			h1 = _x86Multiply(h1, 5) + 0x561ccd1b;
-			
+
 			k2 = _x86Multiply(k2, c2);
 			k2 = _x86Rotl(k2, 16);
 			k2 = _x86Multiply(k2, c3);
 			h2 ^= k2;
-			
+
 			h2 = _x86Rotl(h2, 17);
 			h2 += h3;
 			h2 = _x86Multiply(h2, 5) + 0x0bcaa747;
-			
+
 			k3 = _x86Multiply(k3, c3);
 			k3 = _x86Rotl(k3, 17);
 			k3 = _x86Multiply(k3, c4);
 			h3 ^= k3;
-			
+
 			h3 = _x86Rotl(h3, 15);
 			h3 += h4;
 			h3 = _x86Multiply(h3, 5) + 0x96cd1c35;
-			
+
 			k4 = _x86Multiply(k4, c4);
 			k4 = _x86Rotl(k4, 18);
 			k4 = _x86Multiply(k4, c1);
 			h4 ^= k4;
-			
+
 			h4 = _x86Rotl(h4, 13);
 			h4 += h1;
 			h4 = _x86Multiply(h4, 5) + 0x32ac3b17;
 		}
-		
+
 		k1 = 0;
 		k2 = 0;
 		k3 = 0;
 		k4 = 0;
-		
+
 		switch (remainder) {
 			case 15:
-				k4 ^= key.charCodeAt(i + 14) << 16;
-			
+				k4 ^= bytes[i + 14] << 16;
+
 			case 14:
-				k4 ^= key.charCodeAt(i + 13) << 8;
-			
+				k4 ^= bytes[i + 13] << 8;
+
 			case 13:
-				k4 ^= key.charCodeAt(i + 12);
+				k4 ^= bytes[i + 12];
 				k4 = _x86Multiply(k4, c4);
 				k4 = _x86Rotl(k4, 18);
 				k4 = _x86Multiply(k4, c1);
 				h4 ^= k4;
-			
+
 			case 12:
-				k3 ^= key.charCodeAt(i + 11) << 24;
-			
+				k3 ^= bytes[i + 11] << 24;
+
 			case 11:
-				k3 ^= key.charCodeAt(i + 10) << 16;
-			
+				k3 ^= bytes[i + 10] << 16;
+
 			case 10:
-				k3 ^= key.charCodeAt(i + 9) << 8;
-			
+				k3 ^= bytes[i + 9] << 8;
+
 			case 9:
-				k3 ^= key.charCodeAt(i + 8);
+				k3 ^= bytes[i + 8];
 				k3 = _x86Multiply(k3, c3);
 				k3 = _x86Rotl(k3, 17);
 				k3 = _x86Multiply(k3, c4);
 				h3 ^= k3;
-			
+
 			case 8:
-				k2 ^= key.charCodeAt(i + 7) << 24;
-			
+				k2 ^= bytes[i + 7] << 24;
+
 			case 7:
-				k2 ^= key.charCodeAt(i + 6) << 16;
-			
+				k2 ^= bytes[i + 6] << 16;
+
 			case 6:
-				k2 ^= key.charCodeAt(i + 5) << 8;
-			
+				k2 ^= bytes[i + 5] << 8;
+
 			case 5:
-				k2 ^= key.charCodeAt(i + 4);
+				k2 ^= bytes[i + 4];
 				k2 = _x86Multiply(k2, c2);
 				k2 = _x86Rotl(k2, 16);
 				k2 = _x86Multiply(k2, c3);
 				h2 ^= k2;
-			
+
 			case 4:
-				k1 ^= key.charCodeAt(i + 3) << 24;
-			
+				k1 ^= bytes[i + 3] << 24;
+
 			case 3:
-				k1 ^= key.charCodeAt(i + 2) << 16;
-			
+				k1 ^= bytes[i + 2] << 16;
+
 			case 2:
-				k1 ^= key.charCodeAt(i + 1) << 8;
-			
+				k1 ^= bytes[i + 1] << 8;
+
 			case 1:
-				k1 ^= key.charCodeAt(i);
+				k1 ^= bytes[i];
 				k1 = _x86Multiply(k1, c1);
 				k1 = _x86Rotl(k1, 15);
 				k1 = _x86Multiply(k1, c2);
 				h1 ^= k1;
 		}
-		
-		h1 ^= key.length;
-		h2 ^= key.length;
-		h3 ^= key.length;
-		h4 ^= key.length;
-		
+
+		h1 ^= bytes.length;
+		h2 ^= bytes.length;
+		h3 ^= bytes.length;
+		h4 ^= bytes.length;
+
 		h1 += h2;
 		h1 += h3;
 		h1 += h4;
 		h2 += h1;
 		h3 += h1;
 		h4 += h1;
-		
+
 		h1 = _x86Fmix(h1);
 		h2 = _x86Fmix(h2);
 		h3 = _x86Fmix(h3);
 		h4 = _x86Fmix(h4);
-		
+
 		h1 += h2;
 		h1 += h3;
 		h1 += h4;
 		h2 += h1;
 		h3 += h1;
 		h4 += h1;
-		
+
 		return ("00000000" + (h1 >>> 0).toString(16)).slice(-8) + ("00000000" + (h2 >>> 0).toString(16)).slice(-8) + ("00000000" + (h3 >>> 0).toString(16)).slice(-8) + ("00000000" + (h4 >>> 0).toString(16)).slice(-8);
 	};
-	
-	
+
+
 	library.x64.hash128 = function (key, seed) {
 		//
 		// Given a string and an optional seed as an int, returns a 128 bit
 		// hash using the x64 flavor of MurmurHash3, as an unsigned hex.
 		//
-		
-		key = key || '';
+
+		var bytes = _utf8Bytes(key);
 		seed = seed || 0;
-		
-		var remainder = key.length % 16;
-		var bytes = key.length - remainder;
-		
+
+		var remainder = bytes.length % 16;
+		var blocks = bytes.length - remainder;
+
 		var h1 = [0, seed];
 		var h2 = [0, seed];
-		
+
 		var k1 = [0, 0];
 		var k2 = [0, 0];
-		
+
 		var c1 = [0x87c37b91, 0x114253d5];
 		var c2 = [0x4cf5ad43, 0x2745937f];
-		
-		for (var i = 0; i < bytes; i = i + 16) {
-			k1 = [((key.charCodeAt(i + 4) & 0xff)) | ((key.charCodeAt(i + 5) & 0xff) << 8) | ((key.charCodeAt(i + 6) & 0xff) << 16) | ((key.charCodeAt(i + 7) & 0xff) << 24), ((key.charCodeAt(i) & 0xff)) | ((key.charCodeAt(i + 1) & 0xff) << 8) | ((key.charCodeAt(i + 2) & 0xff) << 16) | ((key.charCodeAt(i + 3) & 0xff) << 24)];
-			k2 = [((key.charCodeAt(i + 12) & 0xff)) | ((key.charCodeAt(i + 13) & 0xff) << 8) | ((key.charCodeAt(i + 14) & 0xff) << 16) | ((key.charCodeAt(i + 15) & 0xff) << 24), ((key.charCodeAt(i + 8) & 0xff)) | ((key.charCodeAt(i + 9) & 0xff) << 8) | ((key.charCodeAt(i + 10) & 0xff) << 16) | ((key.charCodeAt(i + 11) & 0xff) << 24)];
-			
+
+		for (var i = 0; i < blocks; i = i + 16) {
+			k1 = [(bytes[i + 4]) | (bytes[i + 5] << 8) | (bytes[i + 6] << 16) | (bytes[i + 7] << 24), (bytes[i]) | (bytes[i + 1] << 8) | (bytes[i + 2] << 16) | (bytes[i + 3] << 24)];
+			k2 = [(bytes[i + 12]) | (bytes[i + 13] << 8) | (bytes[i + 14] << 16) | (bytes[i + 15] << 24), (bytes[i + 8]) | (bytes[i + 9] << 8) | (bytes[i + 10] << 16) | (bytes[i + 11] << 24)];
+
 			k1 = _x64Multiply(k1, c1);
 			k1 = _x64Rotl(k1, 31);
 			k1 = _x64Multiply(k1, c2);
 			h1 = _x64Xor(h1, k1);
-			
+
 			h1 = _x64Rotl(h1, 27);
 			h1 = _x64Add(h1, h2);
 			h1 = _x64Add(_x64Multiply(h1, [0, 5]), [0, 0x52dce729]);
-			
+
 			k2 = _x64Multiply(k2, c2);
 			k2 = _x64Rotl(k2, 33);
 			k2 = _x64Multiply(k2, c1);
 			h2 = _x64Xor(h2, k2);
-			
+
 			h2 = _x64Rotl(h2, 31);
 			h2 = _x64Add(h2, h1);
 			h2 = _x64Add(_x64Multiply(h2, [0, 5]), [0, 0x38495ab5]);
 		}
-		
+
 		k1 = [0, 0];
 		k2 = [0, 0];
-		
+
 		switch(remainder) {
 			case 15:
-				k2 = _x64Xor(k2, _x64LeftShift([0, key.charCodeAt(i + 14)], 48));
-			
+				k2 = _x64Xor(k2, _x64LeftShift([0, bytes[i + 14]], 48));
+
 			case 14:
-				k2 = _x64Xor(k2, _x64LeftShift([0, key.charCodeAt(i + 13)], 40));
-			
+				k2 = _x64Xor(k2, _x64LeftShift([0, bytes[i + 13]], 40));
+
 			case 13:
-				k2 = _x64Xor(k2, _x64LeftShift([0, key.charCodeAt(i + 12)], 32));
-			
+				k2 = _x64Xor(k2, _x64LeftShift([0, bytes[i + 12]], 32));
+
 			case 12:
-				k2 = _x64Xor(k2, _x64LeftShift([0, key.charCodeAt(i + 11)], 24));
-			
+				k2 = _x64Xor(k2, _x64LeftShift([0, bytes[i + 11]], 24));
+
 			case 11:
-				k2 = _x64Xor(k2, _x64LeftShift([0, key.charCodeAt(i + 10)], 16));
-			
+				k2 = _x64Xor(k2, _x64LeftShift([0, bytes[i + 10]], 16));
+
 			case 10:
-				k2 = _x64Xor(k2, _x64LeftShift([0, key.charCodeAt(i + 9)], 8));
-			
+				k2 = _x64Xor(k2, _x64LeftShift([0, bytes[i + 9]], 8));
+
 			case 9:
-				k2 = _x64Xor(k2, [0, key.charCodeAt(i + 8)]);
+				k2 = _x64Xor(k2, [0, bytes[i + 8]]);
 				k2 = _x64Multiply(k2, c2);
 				k2 = _x64Rotl(k2, 33);
 				k2 = _x64Multiply(k2, c1);
 				h2 = _x64Xor(h2, k2);
-			
+
 			case 8:
-				k1 = _x64Xor(k1, _x64LeftShift([0, key.charCodeAt(i + 7)], 56));
-			
+				k1 = _x64Xor(k1, _x64LeftShift([0, bytes[i + 7]], 56));
+
 			case 7:
-				k1 = _x64Xor(k1, _x64LeftShift([0, key.charCodeAt(i + 6)], 48));
-			
+				k1 = _x64Xor(k1, _x64LeftShift([0, bytes[i + 6]], 48));
+
 			case 6:
-				k1 = _x64Xor(k1, _x64LeftShift([0, key.charCodeAt(i + 5)], 40));
-			
+				k1 = _x64Xor(k1, _x64LeftShift([0, bytes[i + 5]], 40));
+
 			case 5:
-				k1 = _x64Xor(k1, _x64LeftShift([0, key.charCodeAt(i + 4)], 32));
-			
+				k1 = _x64Xor(k1, _x64LeftShift([0, bytes[i + 4]], 32));
+
 			case 4:
-				k1 = _x64Xor(k1, _x64LeftShift([0, key.charCodeAt(i + 3)], 24));
-			
+				k1 = _x64Xor(k1, _x64LeftShift([0, bytes[i + 3]], 24));
+
 			case 3:
-				k1 = _x64Xor(k1, _x64LeftShift([0, key.charCodeAt(i + 2)], 16));
-			
+				k1 = _x64Xor(k1, _x64LeftShift([0, bytes[i + 2]], 16));
+
 			case 2:
-				k1 = _x64Xor(k1, _x64LeftShift([0, key.charCodeAt(i + 1)], 8));
-			
+				k1 = _x64Xor(k1, _x64LeftShift([0, bytes[i + 1]], 8));
+
 			case 1:
-				k1 = _x64Xor(k1, [0, key.charCodeAt(i)]);
+				k1 = _x64Xor(k1, [0, bytes[i]]);
 				k1 = _x64Multiply(k1, c1);
 				k1 = _x64Rotl(k1, 31);
 				k1 = _x64Multiply(k1, c2);
 				h1 = _x64Xor(h1, k1);
 		}
-		
-		h1 = _x64Xor(h1, [0, key.length]);
-		h2 = _x64Xor(h2, [0, key.length]);
-		
+
+		h1 = _x64Xor(h1, [0, bytes.length]);
+		h2 = _x64Xor(h2, [0, bytes.length]);
+
 		h1 = _x64Add(h1, h2);
 		h2 = _x64Add(h2, h1);
-		
+
 		h1 = _x64Fmix(h1);
 		h2 = _x64Fmix(h2);
-		
+
 		h1 = _x64Add(h1, h2);
 		h2 = _x64Add(h2, h1);
-		
+
 		return ("00000000" + (h1[0] >>> 0).toString(16)).slice(-8) + ("00000000" + (h1[1] >>> 0).toString(16)).slice(-8) + ("00000000" + (h2[0] >>> 0).toString(16)).slice(-8) + ("00000000" + (h2[1] >>> 0).toString(16)).slice(-8);
 	};
-	
-	
-	
-	
+
+
+
+
 	// INITIALIZATION
 	// --------------
-	
+
 	// Export murmurHash3 for CommonJS, either as an AMD module or just as part
 	// of the global object.
 	if (typeof exports !== 'undefined') {
 		if (typeof module !== 'undefined' && module.exports) {
 			exports = module.exports = library;
 		}
-		
+
 		exports.murmurHash3 = library;
 	}
-	
+
 	else if (typeof define === 'function' && define.amd) {
 		define([], function() {
 			return library;
 		});
 	}
-	
+
 	else {
 		// Use murmurHash3.noConflict to restore `murmurHash3` back to its
 		// original value. Returns a reference to the library object, to allow
 		// it to be used under a different name.
 		library._murmurHash3 = root.murmurHash3
-		
+
 		library.noConflict = function () {
 			root.murmurHash3 = library._murmurHash3;
 			library._murmurHash3 = undefined;
 			library.noConflict = undefined;
-			
+
 			return library;
 		};
-		
+
 		root.murmurHash3 = library;
 	}
 })(this);

--- a/tests.html
+++ b/tests.html
@@ -14,7 +14,7 @@
 	<script>
 		'use strict';
 		var noConflict;
-		
+
 		if (
 			// x86 32bit Tests
 			(murmurHash3.x86.hash32("I will not buy this record, it is scratched.") === 2832214938) &&
@@ -25,7 +25,8 @@
 			(murmurHash3.x86.hash32("0123") === 3558446240) &&
 			(murmurHash3.x86.hash32("01234") === 433070448) &&
 			(murmurHash3.x86.hash32("", 1) === 1364076727) &&
-			
+			(murmurHash3.x86.hash32("My 🚀 is full of 🦎.") === 1818098979) &&
+
 			// x86 128bit Tests
 			(murmurHash3.x86.hash128("I will not buy this tobacconist's, it is scratched.") === "9b5b7ba2ef3f7866889adeaf00f3f98e") &&
 			(murmurHash3.x86.hash128("") === "00000000000000000000000000000000") &&
@@ -46,7 +47,8 @@
 			(murmurHash3.x86.hash128("0123456789abcde") === "3c76c46d4d0818c0add433daa78673fa") &&
 			(murmurHash3.x86.hash128("0123456789abcdef") === "fb7d440936aed30a48ad1d9b572b3bfd") &&
 			(murmurHash3.x86.hash128("", 1) === "88c4adec54d201b954d201b954d201b9") &&
-			
+			(murmurHash3.x86.hash128("My 🚀 is full of 🦎.") === "e616d85ffee7f678dab461995b5bb90f") &&
+
 			// x64 128bit Tests
 			(murmurHash3.x64.hash128("I will not buy this tobacconist's, it is scratched.") === "d30654abbd8227e367d73523f0079673") &&
 			(murmurHash3.x64.hash128("") === "00000000000000000000000000000000") &&
@@ -67,7 +69,8 @@
 			(murmurHash3.x64.hash128("0123456789abcde") === "a62dd5f6c0bf23514fccf50c7c544cf0") &&
 			(murmurHash3.x64.hash128("0123456789abcdef") === "4be06d94cf4ad1a787c35b5c63a708da") &&
 			(murmurHash3.x64.hash128("", 1) === "4610abe56eff5cb551622daa78f83583") &&
-			
+			(murmurHash3.x64.hash128("My 🚀 is full of 🦎.") === "d047391e58c6c9dfccde62c92e049f50") &&
+
 			// noConflict Test
 			(noConflict = murmurHash3.noConflict()) &&
 			(murmurHash3 === "Some Old Value") &&

--- a/tests.html
+++ b/tests.html
@@ -6,7 +6,7 @@
 			'use strict';
 			var murmurHash3 = "Some Old Value";
 		</script>
-		<script type="text/javascript" src="./murmurHash3.min.js"></script>
+		<script type="text/javascript" src="./murmurHash3.js"></script>
 	</head>
 	<body>
 		Test(s) Failed.


### PR DESCRIPTION
Fixes #4 ([read more here](https://cimi.io/murmurhash3js-revisited)).

After this change, the library will encode the string received as input into utf-8 bytes and feed those to the hashing algorithm. This makes this implementation conform to the output from the C++ reference implementation. All existing tests passed and I've added a few new ones.

My text editor was configured to clean up whitespace, I only noticed the diff after I implemented the change. Sorry for the noise!

I haven't included a `TextEncoder` polyfill as the library doesn't have a way import dependencies or  package multiple files. The polyfills I found had more source code than this library, so pasting the source in the same file felt wrong. 😊

I haven't regenerated the minified output as I don't know how you'd like to do that.

I haven't tagged a new version as I'm not sure how releases work. I recommend tagging this change a new major version, even if it's backwards compatible for a subset of the input. Replacing the old version should be a voluntary / conscious decision as values for some inputs will be different.